### PR TITLE
Move call-bind to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,14 +51,14 @@
 		"define-properties": "^1.2.1",
 		"es-errors": "^1.3.0",
 		"gopd": "^1.2.0",
-		"has-tostringtag": "^1.0.2"
+		"has-tostringtag": "^1.0.2",
+		"call-bind": "^1.0.8"
 	},
 	"devDependencies": {
 		"@es-shims/api": "^3.0.2",
 		"@ljharb/eslint-config": "^21.1.1",
 		"@types/node": "^22.15.21",
 		"auto-changelog": "^2.5.0",
-		"call-bind": "^1.0.8",
 		"encoding": "^0.1.13",
 		"es-value-fixtures": "^1.7.1",
 		"eslint": "=8.8.0",


### PR DESCRIPTION
Move call-bind to dependencies as it is depended on by implementation.js